### PR TITLE
Member Service/Impl and test code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
 ﻿# SNS_Project
 
-sns-clone-springboot로 이름 바꿀수 있을까요??
+## Domain  
+Member  
+Board  
+
+## Repository
+Member Repository - Memory Member Repository. JPA Member Repository  
+Board Repository - Memory Board Repository. JPA Board Repository  
+Follow Repository - Memory Follow Repository. JPA Follow Repository  
+Like Repository - Memory Like Repository. JPA Like Repository  
+
+## Service
+Member Service - Member Service Impl  
+Board Service - Board Service Impl  
+Follow Service - Follow Service Impl  
+Like Service - Like Service Impl
+
+## Controller
+Member Controller  
+Board Controller  
+Follow Controller  
+Like Controller  
+
+## TODO  
+[x] hashmap memory db & simple login/signup page (baseline)   
+[x] Member Service/Controller/Repository Baseline   
+[ ] Board Service/Controller/Repository Baseline   
+[ ] Like, Follow Implement   
+[ ] JPA   
+[ ] Spring Security   
+[ ] Bootstrap   
+[ ] OAuth2   

--- a/src/main/java/afoc/snsclonespringboot/member/JpaMemberRepository.java
+++ b/src/main/java/afoc/snsclonespringboot/member/JpaMemberRepository.java
@@ -63,23 +63,31 @@ public class JpaMemberRepository implements MemberRepository{
         return findMember.getBoardList();
     }
 
+    // TODO
     @Override
-    public Optional<Member> updateMemberByMemberId(Long memberId) {
+    public Boolean updateMember(Member member) {
 
-        Member findMember = findMemberByMemberId(memberId).get();
-
-        // update
-
-        return Optional.of(findMember);
+//        Member findMember = findMemberByMemberId(memberId).get();
+//
+//        // update
+//
+//        return Optional.of(findMember);
+        return false;
     }
 
+    // TODO
     @Override
     public Boolean deleteMemberByMemberId(Long memberId) {
 
-        if(findMemberByMemberId(memberId).get() != null){
-            em.remove(em.find(Member.class, memberId));
-            return true;
-        }
+//        if(findMemberByMemberId(memberId).get() != null){
+//            em.remove(em.find(Member.class, memberId));
+//            return true;
+//        }
         return false;
+    }
+
+    // TODO
+    @Override
+    public void clear(){
     }
 }

--- a/src/main/java/afoc/snsclonespringboot/member/MemberController.java
+++ b/src/main/java/afoc/snsclonespringboot/member/MemberController.java
@@ -19,7 +19,7 @@ public class MemberController {
 
     @PostMapping("/login")
     public String login(LoginForm loginForm){
-        Optional<Member> foundMember = memberService.findByEmail(loginForm.getEmail());
+        Optional<Member> foundMember = memberService.findMemberByEmail(loginForm.getEmail());
         if (foundMember.isPresent() &&
                 loginForm.getPassword().equals(foundMember.get().getPassword())) {
             return "redirect:/main";

--- a/src/main/java/afoc/snsclonespringboot/member/MemberRepository.java
+++ b/src/main/java/afoc/snsclonespringboot/member/MemberRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 public interface MemberRepository {
 
+    // Member CRUD
+
     // 등록
     Member save(Member member);
 
@@ -21,9 +23,19 @@ public interface MemberRepository {
     List<Board> findBoardListByMemberId(Long memberId);
 
     // Member id 이용해 수정
-    Optional<Member> updateMemberByMemberId(Long memberId);
+    Boolean updateMember(Member member);
 
     // Member id 이용해 삭제
     // return 값 성공/실패
     Boolean deleteMemberByMemberId(Long memberId);
+
+    /*------------------------------------------------------*/
+
+    // TODO
+    // Follow
+
+
+    /*------------------------------------------------------*/
+    // all clear for test
+    void clear();
 }

--- a/src/main/java/afoc/snsclonespringboot/member/MemberService.java
+++ b/src/main/java/afoc/snsclonespringboot/member/MemberService.java
@@ -10,7 +10,16 @@ public interface MemberService {
     - 팔로워 목록 조회
     - 팔로이 목록 조회
      */
-    boolean join(Member member);
-    Optional<Member> findMemberById(Long memberId);
-    Optional<Member> findByEmail(String email);
+
+    // Member CRUD
+    Boolean join(Member member);
+    Optional<Member> findMemberById(Long id);
+    Optional<Member> findMemberByEmail(String email);
+    Boolean updateMember(Member member);
+    Boolean deleteMemberById(Long id);
+
+    // TODO
+    // Follow
+//    Boolean follow(Long followerId, Long followeeId);
+//    Boolean unfollow(Long followerId, Long followeeId);
 }

--- a/src/main/java/afoc/snsclonespringboot/member/MemberServiceImpl.java
+++ b/src/main/java/afoc/snsclonespringboot/member/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package afoc.snsclonespringboot.member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -10,19 +11,48 @@ import java.util.Optional;
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
 
-    public boolean join(Member member){
-        memberRepository.save(member);
-        return true;
-    }
-
-    @Override
-    public Optional<Member> findByEmail(String email) {
-        return memberRepository.findMemberByMemberEmail(email);
+    public Boolean join(Member member){
+        Optional<Member> foundMember = findMemberByEmail(member.getEmail());
+        if (foundMember.isPresent()) {
+            return false;
+        } else {
+            memberRepository.save(member);
+            return true;
+        }
     }
 
     @Override
     public Optional<Member> findMemberById(Long memberId){
         return memberRepository.findMemberByMemberId(memberId);
     }
+
+    @Override
+    public Optional<Member> findMemberByEmail(String email) {
+        return memberRepository.findMemberByMemberEmail(email);
+    }
+
+    @Override
+    public Boolean updateMember(Member member) {
+        Optional<Member> foundMember = findMemberById(member.getId());
+        if (foundMember.isEmpty()) {
+            return false;
+        } else {
+            String email1 = foundMember.get().getEmail();
+            String email2 = member.getEmail();
+            if (!Objects.equals(email1, email2)){
+                return false;
+            } else {
+                memberRepository.updateMember(member);
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public Boolean deleteMemberById(Long id) {
+        return memberRepository.deleteMemberByMemberId(id);
+    }
+
+
 
 }

--- a/src/main/java/afoc/snsclonespringboot/member/MemoryMemberRepository.java
+++ b/src/main/java/afoc/snsclonespringboot/member/MemoryMemberRepository.java
@@ -9,8 +9,11 @@ import java.util.Optional;
 
 public class MemoryMemberRepository implements MemberRepository{
 
-    private static Map<Long, Member> store = new HashMap<>();
+    private static final Map<Long, Member> store = new HashMap<>();
     private static long sequence = 0L;
+
+    /*------------------------------------------------------*/
+    // Member CRUD
 
     @Override
     public Member save(Member member) {
@@ -40,14 +43,31 @@ public class MemoryMemberRepository implements MemberRepository{
     }
 
     @Override
-    public Optional<Member> updateMemberByMemberId(Long memberId) {
-        return Optional.empty();
+    public Boolean updateMember(Member member) {
+        Member returnValue = store.get(member.getId());
+        if (returnValue != null){
+            store.put(member.getId(), member);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override
     public Boolean deleteMemberByMemberId(Long memberId) {
         Member returnValue = store.remove(memberId);
-
         return returnValue != null;
+    }
+
+    /*------------------------------------------------------*/
+    // Follow
+
+    /*------------------------------------------------------*/
+    // Extras
+
+    @Override
+    public void clear(){
+        store.clear();
+        sequence = 0L;
     }
 }

--- a/src/test/java/afoc/snsclonespringboot/member/MemberServiceTest.java
+++ b/src/test/java/afoc/snsclonespringboot/member/MemberServiceTest.java
@@ -1,0 +1,344 @@
+package afoc.snsclonespringboot.member;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class MemberServiceTest {
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @AfterEach
+    public void afterEach(){
+        memberRepository.clear();
+    }
+
+    /*------------------------------------------------------*/
+    // Boolean join(Member member)
+
+    @Test
+    void joinSingleTest() {
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        boolean isSuccess1 = memberService.join(member1);
+
+        // successful join
+        assertThat(isSuccess1).isTrue();
+    }
+
+    @Test
+    void joinDoubleTest() {
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        Member member2 = Member.builder()
+                .username("test2")
+                .nickname("nick2")
+                .password("2345")
+                .email("test2@test.com")
+                .build();
+
+        boolean isSuccess1 = memberService.join(member1);
+        boolean isSuccess2 = memberService.join(member2);
+
+        // successful join
+        assertThat(isSuccess1).isTrue();
+        assertThat(isSuccess2).isTrue();
+    }
+
+    @Test
+    void joinDuplicateTest1() {
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        Member member2 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test2@test.com")
+                .build();
+
+        boolean isSuccess1 = memberService.join(member1);
+        boolean isSuccess2 = memberService.join(member2);
+
+        // successful join
+        assertThat(isSuccess1).isTrue();
+        assertThat(isSuccess2).isTrue();
+    }
+
+    @Test
+    void joinDuplicateTest2() {
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        Member member2 = Member.builder()
+                .username("test2")
+                .nickname("nick2")
+                .password("2345")
+                .email("test1@test.com")
+                .build();
+
+        boolean isSuccess1 = memberService.join(member1);
+        boolean isSuccess2 = memberService.join(member2);
+
+        // successful join
+        assertThat(isSuccess1).isTrue();
+        // join failure
+        assertThat(isSuccess2).isFalse();
+    }
+
+    /*------------------------------------------------------*/
+    // Optional<Member> findMemberByEmail(String email)
+
+    @Test
+    void findMemberByEmailSingleTest(){
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        boolean isSuccess1 = memberService.join(member1);
+        Optional<Member> foundMember1ByEmail = memberService.findMemberByEmail("test1@test.com");
+
+        // successful join
+        assertThat(isSuccess1).isTrue();
+
+        // Not null
+        assertThat(foundMember1ByEmail).isPresent();
+
+        // must same value
+        assertThat(member1).isEqualTo(foundMember1ByEmail.get());
+    }
+
+    @Test
+    void findMemberByEmailDoubleTest(){
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        Member member2 = Member.builder()
+                .username("test2")
+                .nickname("nick2")
+                .password("2345")
+                .email("test2@test.com")
+                .build();
+
+        boolean isSuccess1 = memberService.join(member1);
+        boolean isSuccess2 = memberService.join(member2);
+        Optional<Member> foundMember1ByEmail = memberService.findMemberByEmail("test1@test.com");
+        Optional<Member> foundMember2ByEmail = memberService.findMemberByEmail("test2@test.com");
+
+        // successful join
+        assertThat(isSuccess1).isTrue();
+        assertThat(isSuccess2).isTrue();
+
+        // Not null
+        assertThat(foundMember1ByEmail).isPresent();
+        assertThat(foundMember2ByEmail).isPresent();
+
+        // must same value
+        assertThat(member1).isEqualTo(foundMember1ByEmail.get());
+        assertThat(member2).isEqualTo(foundMember2ByEmail.get());
+    }
+
+    /*------------------------------------------------------*/
+    // Optional<Member> findMemberById(Long id)
+
+    @Test
+    void findMemberByIdSingleTest(){
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        boolean isSuccess1 = memberService.join(member1);
+        Optional<Member> foundMember1ById = memberService.findMemberById(1L);
+
+        // successful join
+        assertThat(isSuccess1).isTrue();
+
+        // Not null
+        assertThat(foundMember1ById).isPresent();
+
+        // must same value
+        assertThat(member1).isEqualTo(foundMember1ById.get());
+    }
+
+    @Test
+    void findMemberByIdDoubleTest() {
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        Member member2 = Member.builder()
+                .username("test2")
+                .nickname("nick2")
+                .password("2345")
+                .email("test2@test.com")
+                .build();
+
+        boolean isSuccess1 = memberService.join(member1);
+        boolean isSuccess2 = memberService.join(member2);
+        Optional<Member> foundMember1ById = memberService.findMemberById(1L);
+        Optional<Member> foundMember2ById = memberService.findMemberById(2L);
+
+        // successful join
+        assertThat(isSuccess1).isTrue();
+        assertThat(isSuccess2).isTrue();
+
+        // Not null
+        assertThat(foundMember1ById).isPresent();
+        assertThat(foundMember2ById).isPresent();
+
+        // must same value
+        assertThat(member1).isEqualTo(foundMember1ById.get());
+        assertThat(member2).isEqualTo(foundMember2ById.get());
+    }
+
+    /*------------------------------------------------------*/
+    // Boolean updateMember(Member member)
+
+    @Test
+    public void updateMemberSimple(){
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        // join
+        boolean isSuccess1 = memberService.join(member1);
+        assertThat(isSuccess1).isTrue(); // successful join
+
+        // find member to be updated
+        Optional<Member> foundMember1ById = memberService.findMemberById(1L);
+        assertThat(foundMember1ById).isPresent(); // Not null
+
+        // set new value
+        Member foundMember1 = foundMember1ById.get();
+        Member updateMember = Member.builder()
+                    .username("test2")
+                    .nickname("nick2")
+                    .password("2345")
+                    .email(foundMember1.getEmail())
+                    .build();
+        updateMember.setId(foundMember1.getId());
+
+        // update
+        boolean isSuccess2 = memberService.updateMember(updateMember);
+        assertThat(isSuccess2).isTrue(); // successful update
+
+        // find updated member
+        Optional<Member> foundUpdatedMember1ById = memberService.findMemberById(1L);
+        assertThat(foundUpdatedMember1ById).isPresent(); // Not null
+
+        // check updated value
+        assertThat(updateMember).isEqualTo(foundUpdatedMember1ById.get());
+    }
+
+    @Test
+    public void updateMemberEmailCheck(){
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        // join
+        boolean isSuccess1 = memberService.join(member1);
+        assertThat(isSuccess1).isTrue(); // successful join
+
+        // find member to be updated
+        Optional<Member> foundMember1ById = memberService.findMemberById(1L);
+        assertThat(foundMember1ById).isPresent(); // Not null
+
+        // set new value
+        Member foundMember1 = foundMember1ById.get();
+        Member updateMember = Member.builder()
+                .username(foundMember1.getUsername())
+                .nickname(foundMember1.getNickname())
+                .password(foundMember1.getPassword())
+                .email("test2@test.com")
+                .build();
+        updateMember.setId(foundMember1.getId());
+
+        // update
+        boolean isSuccess2 = memberService.updateMember(updateMember);
+        assertThat(isSuccess2).isFalse(); // update failure
+
+        // find updated member
+        Optional<Member> foundUpdatedMember1ById = memberService.findMemberById(1L);
+        assertThat(foundUpdatedMember1ById).isPresent(); // Not null
+
+        // check not update value
+        assertThat(member1).isEqualTo(foundUpdatedMember1ById.get());
+    }
+
+    /*------------------------------------------------------*/
+    // Boolean deleteMemberById(Long id);
+
+    @Test
+    public void deleteMemberById(){
+        Member member1 = Member.builder()
+                .username("test1")
+                .nickname("nick1")
+                .password("1234")
+                .email("test1@test.com")
+                .build();
+
+        // join
+        boolean isSuccess1 = memberService.join(member1);
+        assertThat(isSuccess1).isTrue(); // successful join
+
+        // delete
+        boolean isSuccess2 = memberService.deleteMemberById(1L);
+        assertThat(isSuccess2).isTrue(); // successful delete
+
+        // check
+        Optional<Member> memberByEmail = memberService.findMemberByEmail("test1@test.com");
+        Optional<Member> memberById = memberService.findMemberById(1L);
+        assertThat(memberByEmail).isEmpty();
+        assertThat(memberById).isEmpty();
+    }
+
+    /*------------------------------------------------------*/
+
+}


### PR DESCRIPTION
1. README 업데이트
2. MemberService의 메소드 수정
   아웃풋 타입 조정
    boolean join(Member member) -> Boolean join(Member member) 

    명칭 조정
    Optional<Member> findByEmail(String email) -> Optional<Member> findMemberByEmail(String email)

    추가
    Boolean updateMember(Member member);
    Boolean deleteMemberById(Long id);
3. MemberRepository 메소드 수정
    아웃풋 타입 및 인풋 타입 조정
    Optional<Member> updateMemberByMemberId(Long memberId) -> Boolean updateMember(Member member)
4. 3번항목에 따른 MemoryMemberRepository 및 JPAMemberRepository 코드 수정 및 주석화 **(수정필요)**
5. MemberService 테스트 코드 작성 (MemberServiceTest)